### PR TITLE
Add Clone derivation to Lnd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use tonic::{
     Interceptor, Response, Status,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Lnd {
     lightning_client: LightningClient<Channel>,
 }


### PR DESCRIPTION
### What
`#[derive(Clone)]`

### Why
Because I forgot. Cloning the underlying client is cheap because [as far as I can tell ](https://docs.rs/tonic/0.3.1/tonic/transport/channel/struct.Channel.html)it's analogous to clone the channel.

### Thanks