### PR TITLE
paths instead of bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,9 @@ hyper = "0.13"
 hyper-openssl = "0.8"
 hex = "0.4"
 
+[dependencies.tokio]
+version = "0.2"
+features = ["fs", "macros"]
+
 [build-dependencies]
 tonic-build = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 name = "lnd"
 
 [dependencies]
-tonic = "0.3.1"
-prost = "0.6.1"
-openssl = "0.10.33"
-hyper = "0.13.10"
-hyper-openssl = "0.8.1"
-hex = "0.4.3"
+tonic = "0.3"
+prost = "0.6"
+openssl = "0.10"
+hyper = "0.13"
+hyper-openssl = "0.8"
+hex = "0.4"
 
 [build-dependencies]
 tonic-build = "0.3.1"


### PR DESCRIPTION
- Downgrade Cargo crate requirements (2 numbers precision)
- Add tokio crate
- Update connect signature to receive paths
