### PR TITLE
Remove unwrap on certificate parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ impl Lnd {
 
     fn connector(certificate_bytes: &[u8]) -> Result<HttpsConnector<HttpConnector>, ErrorStack> {
         let mut connector = SslConnector::builder(SslMethod::tls())?;
-        let ca = X509::from_pem(&certificate_bytes).unwrap();
+        let ca = X509::from_pem(&certificate_bytes)?;
 
         connector.cert_store_mut().add_cert(ca)?;
         connector.set_alpn_protos(b"\x02h2")?;


### PR DESCRIPTION
Why wasn't it ? before?