### PR TITLE
bump: updating deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ name = "lnd"
 [dependencies]
 async-trait = { version = "0.1.0", default-features = false }
 hex = { version = "0.4.0", features = ["std"], default-features = false }
-prost = { version = "0.12.0", features = ["prost-derive"], default-features = false }
+prost = { version = "0.13.0", features = ["prost-derive"], default-features = false }
 thiserror = { version = "1.0.0", default-features = false }
-tonic = { version = "0.11.0", features = ["codegen", "prost", "tls", "transport"], default-features = false }
+tonic = { version = "0.12.0", features = ["codegen", "prost", "tls", "transport"], default-features = false }
 tracing = { version = "0.1.0", default-features = false }
 
 [build-dependencies]
-tonic-build = "0.11.0"
+tonic-build = "0.12.0"


### PR DESCRIPTION
# Description
Bumping `tonic` version from 0.11 to 0.12 and `prost` from 0.12 to 0.13.

