### PR TITLE
bump: opentelemetry to 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "lnd"
 
 [dependencies]
 hex = { version = "0.4.0", features = ["std"], default-features = false }
-opentelemetry = { version = "0.26.0", features = ["trace"], default-features = false }
+opentelemetry = { version = "0.27.0", features = ["trace"], default-features = false }
 prost = { version = "0.13.0", features = ["prost-derive"], default-features = false }
 thiserror = { version = "1.0.0", default-features = false }
 tonic = { version = "0.12.0", features = ["codegen", "prost", "tls", "transport"], default-features = false }


### PR DESCRIPTION
# Description
otel changelog: https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#0270