### PR TITLE
ENG-9691 | LND | Re-vendor protos from lnd v0.21.1-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ⚡️ lnd-rs
 
 ![ci-checks-out](https://github.com/bipa-app/lnd-rs/actions/workflows/checks.yml/badge.svg)
-![lnd-version](https://img.shields.io/badge/lnd-v.0.13.1--beta-blue)
+![lnd-version](https://img.shields.io/badge/lnd-v.0.21.1--beta-blue)
 
 This project has the goal of bridging a gap between lnd and rust with a gRPC shaped bridge.
 The project is incomplete and under development.

--- a/build.rs
+++ b/build.rs
@@ -3,9 +3,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     tonic_prost_build::configure()
         .build_server(false)
-        // invoices.proto uses proto3 `optional`, which protoc only accepts unflagged
-        // from 3.15. Ubuntu 22.04 — what bipa's CI runners are — ships 3.12.4, so
-        // without this a consumer fails to build us. Still accepted by current protoc.
         .protoc_arg("--experimental_allow_proto3_optional")
         .out_dir(out_dir)
         .compile_protos(

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     tonic_prost_build::configure()
         .build_server(false)
+        // invoices.proto uses proto3 `optional`, which protoc only accepts unflagged
+        // from 3.15. Ubuntu 22.04 — what bipa's CI runners are — ships 3.12.4, so
+        // without this a consumer fails to build us. Still accepted by current protoc.
+        .protoc_arg("--experimental_allow_proto3_optional")
         .out_dir(out_dir)
         .compile_protos(
             &[

--- a/proto/chainkit.proto
+++ b/proto/chainkit.proto
@@ -7,52 +7,68 @@ option go_package = "github.com/lightningnetwork/lnd/lnrpc/chainrpc";
 // ChainKit is a service that can be used to get information from the
 // chain backend.
 service ChainKit {
-  /* lncli: `chain getblock`
-  GetBlock returns a block given the corresponding block hash.
-  */
-  rpc GetBlock(GetBlockRequest) returns (GetBlockResponse);
+    /* lncli: `chain getblock`
+    GetBlock returns a block given the corresponding block hash.
+    */
+    rpc GetBlock (GetBlockRequest) returns (GetBlockResponse);
 
-  /* lncli: `chain getbestblock`
-  GetBestBlock returns the block hash and current height from the valid
-  most-work chain.
-  */
-  rpc GetBestBlock(GetBestBlockRequest) returns (GetBestBlockResponse);
+    /* lncli: `chain getblockheader`
+    GetBlockHeader returns a block header with a particular block hash.
+    */
+    rpc GetBlockHeader (GetBlockHeaderRequest) returns (GetBlockHeaderResponse);
 
-  /* lncli: `chain getblockhash`
-  GetBlockHash returns the hash of the block in the best blockchain
-  at the given height.
-  */
-  rpc GetBlockHash(GetBlockHashRequest) returns (GetBlockHashResponse);
+    /* lncli: `chain getbestblock`
+    GetBestBlock returns the block hash and current height from the valid
+    most-work chain.
+    */
+    rpc GetBestBlock (GetBestBlockRequest) returns (GetBestBlockResponse);
+
+    /* lncli: `chain getblockhash`
+    GetBlockHash returns the hash of the block in the best blockchain
+    at the given height.
+    */
+    rpc GetBlockHash (GetBlockHashRequest) returns (GetBlockHashResponse);
 }
 
 message GetBlockRequest {
-  // The hash of the requested block.
-  bytes block_hash = 1;
+    // The hash of the requested block.
+    bytes block_hash = 1;
 }
 
 // TODO(ffranr): The neutrino GetBlock response includes many
 // additional helpful fields. Consider adding them here also.
 message GetBlockResponse {
-  // The raw bytes of the requested block.
-  bytes raw_block = 1;
+    // The raw bytes of the requested block.
+    bytes raw_block = 1;
 }
 
-message GetBestBlockRequest {}
+message GetBlockHeaderRequest {
+    // The hash of the block with the requested header.
+    bytes block_hash = 1;
+}
+
+message GetBlockHeaderResponse {
+    // The header of the block with the requested hash.
+    bytes raw_block_header = 1;
+}
+
+message GetBestBlockRequest {
+}
 
 message GetBestBlockResponse {
-  // The hash of the best block.
-  bytes block_hash = 1;
+    // The hash of the best block.
+    bytes block_hash = 1;
 
-  // The height of the best block.
-  int32 block_height = 2;
+    // The height of the best block.
+    int32 block_height = 2;
 }
 
 message GetBlockHashRequest {
-  // Block height of the target best chain block.
-  int64 block_height = 1;
+    // Block height of the target best chain block.
+    int64 block_height = 1;
 }
 
 message GetBlockHashResponse {
-  // The hash of the best block at the specified height.
-  bytes block_hash = 1;
+    // The hash of the best block at the specified height.
+    bytes block_hash = 1;
 }

--- a/proto/invoices.proto
+++ b/proto/invoices.proto
@@ -1,10 +1,28 @@
 syntax = "proto3";
 
-import "lightning.proto";
-
 package invoicesrpc;
 
+import "lightning.proto";
+
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/invoicesrpc";
+
+/*
+ * Comments in this file will be directly parsed into the API
+ * Documentation as descriptions of the associated method, message, or field.
+ * These descriptions should go right above the definition of the object, and
+ * can be in either block or // comment format.
+ *
+ * An RPC method can be matched to an lncli command by placing a line in the
+ * beginning of the description in exactly the following format:
+ * lncli: `methodname`
+ *
+ * Failure to specify the exact name of the command will cause documentation
+ * generation to fail.
+ *
+ * More information on how exactly the gRPC documentation is generated from
+ * this proto file can be found here:
+ * https://github.com/lightninglabs/lightning-api
+ */
 
 // Invoices is a service that can be used to create, accept, settle and cancel
 // invoices.
@@ -17,30 +35,39 @@ service Invoices {
     rpc SubscribeSingleInvoice (SubscribeSingleInvoiceRequest)
         returns (stream lnrpc.Invoice);
 
-    /*
+    /* lncli: `cancelinvoice`
     CancelInvoice cancels a currently open invoice. If the invoice is already
     canceled, this call will succeed. If the invoice is already settled, it will
     fail.
     */
     rpc CancelInvoice (CancelInvoiceMsg) returns (CancelInvoiceResp);
 
-    /*
+    /* lncli: `addholdinvoice`
     AddHoldInvoice creates a hold invoice. It ties the invoice to the hash
     supplied in the request.
     */
     rpc AddHoldInvoice (AddHoldInvoiceRequest) returns (AddHoldInvoiceResp);
 
-    /*
+    /* lncli: `settleinvoice`
     SettleInvoice settles an accepted invoice. If the invoice is already
     settled, this call will succeed.
     */
     rpc SettleInvoice (SettleInvoiceMsg) returns (SettleInvoiceResp);
 
     /*
-    LookupInvoiceV2 attempts to look up at invoice. An invoice can be refrenced
+    LookupInvoiceV2 attempts to look up at invoice. An invoice can be referenced
     using either its payment hash, payment address, or set ID.
     */
     rpc LookupInvoiceV2 (LookupInvoiceMsg) returns (lnrpc.Invoice);
+
+    /*
+    HtlcModifier is a bidirectional streaming RPC that allows a client to
+    intercept and modify the HTLCs that attempt to settle the given invoice. The
+    server will send HTLCs of invoices to the client and the client can modify
+    some aspects of the HTLC in order to pass the invoice acceptance tests.
+    */
+    rpc HtlcModifier (stream HtlcModifyResponse)
+        returns (stream HtlcModifyRequest);
 }
 
 message CancelInvoiceMsg {
@@ -120,8 +147,9 @@ message AddHoldInvoiceResp {
     uint64 add_index = 2;
 
     /*
-    The payment address of the generated invoice. This value should be used
-    in all payments for this invoice as we require it for end to end
+    The payment address of the generated invoice. This is also called
+    the payment secret in specifications (e.g. BOLT 11). This value should
+    be used in all payments for this invoice as we require it for end to end
     security.
     */
     bytes payment_addr = 3;
@@ -172,4 +200,52 @@ message LookupInvoiceMsg {
     }
 
     LookupModifier lookup_modifier = 4;
+}
+
+// CircuitKey is a unique identifier for an HTLC.
+message CircuitKey {
+    // The id of the channel that the is part of this circuit.
+    uint64 chan_id = 1;
+
+    // The index of the incoming htlc in the incoming channel.
+    uint64 htlc_id = 2;
+}
+
+message HtlcModifyRequest {
+    // The invoice the intercepted HTLC is attempting to settle. The HTLCs in
+    // the invoice are only HTLCs that have already been accepted or settled,
+    // not including the current intercepted HTLC.
+    lnrpc.Invoice invoice = 1;
+
+    // The unique identifier of the HTLC of this intercepted HTLC.
+    CircuitKey exit_htlc_circuit_key = 2;
+
+    // The amount in milli-satoshi that the exit HTLC is attempting to pay.
+    uint64 exit_htlc_amt = 3;
+
+    // The absolute expiry height of the exit HTLC.
+    uint32 exit_htlc_expiry = 4;
+
+    // The current block height.
+    uint32 current_height = 5;
+
+    // The wire message custom records of the exit HTLC.
+    map<uint64, bytes> exit_htlc_wire_custom_records = 6;
+}
+
+message HtlcModifyResponse {
+    // The circuit key of the HTLC that the client wants to modify.
+    CircuitKey circuit_key = 1;
+
+    // The modified amount in milli-satoshi that the exit HTLC is paying. This
+    // value can be different from the actual on-chain HTLC amount, in case the
+    // HTLC carries other valuable items, as can be the case with custom channel
+    // types.
+    optional uint64 amt_paid = 2;
+
+    // This flag indicates whether the HTLCs associated with the invoices should
+    // be cancelled. The interceptor client may set this field if some
+    // unexpected behavior is encountered. Setting this will ignore the amt_paid
+    // field.
+    bool cancel_set = 3;
 }

--- a/proto/lightning.proto
+++ b/proto/lightning.proto
@@ -143,6 +143,13 @@ service Lightning {
     */
     rpc GetInfo (GetInfoRequest) returns (GetInfoResponse);
 
+    /* lncli: 'getdebuginfo'
+    GetDebugInfo returns debug information concerning the state of the daemon
+    and its subsystems. This includes the full configuration and the latest log
+    entries from the log file.
+    */
+    rpc GetDebugInfo (GetDebugInfoRequest) returns (GetDebugInfoResponse);
+
     /** lncli: `getrecoveryinfo`
     GetRecoveryInfo returns information concerning the recovery mode including
     whether it's in a recovery mode, whether the recovery is finished, and the
@@ -255,42 +262,6 @@ service Lightning {
     */
     rpc AbandonChannel (AbandonChannelRequest) returns (AbandonChannelResponse);
 
-    /* lncli: `sendpayment`
-    Deprecated, use routerrpc.SendPaymentV2. SendPayment dispatches a
-    bi-directional streaming RPC for sending payments through the Lightning
-    Network. A single RPC invocation creates a persistent bi-directional
-    stream allowing clients to rapidly send payments through the Lightning
-    Network with a single persistent connection.
-    */
-    rpc SendPayment (stream SendRequest) returns (stream SendResponse) {
-        option deprecated = true;
-    }
-
-    /*
-    SendPaymentSync is the synchronous non-streaming version of SendPayment.
-    This RPC is intended to be consumed by clients of the REST proxy.
-    Additionally, this RPC expects the destination's public key and the payment
-    hash (if any) to be encoded as hex strings.
-    */
-    rpc SendPaymentSync (SendRequest) returns (SendResponse);
-
-    /* lncli: `sendtoroute`
-    Deprecated, use routerrpc.SendToRouteV2. SendToRoute is a bi-directional
-    streaming RPC for sending payment through the Lightning Network. This
-    method differs from SendPayment in that it allows users to specify a full
-    route manually. This can be used for things like rebalancing, and atomic
-    swaps.
-    */
-    rpc SendToRoute (stream SendToRouteRequest) returns (stream SendResponse) {
-        option deprecated = true;
-    }
-
-    /*
-    SendToRouteSync is a synchronous version of SendToRoute. It Will block
-    until the payment either fails or succeeds.
-    */
-    rpc SendToRouteSync (SendToRouteRequest) returns (SendResponse);
-
     /* lncli: `addinvoice`
     AddInvoice attempts to add a new invoice to the invoice database. Any
     duplicated invoices are rejected, therefore all invoices *must* have a
@@ -322,12 +293,19 @@ service Lightning {
     optionally specify the add_index and/or the settle_index. If the add_index
     is specified, then we'll first start by sending add invoice events for all
     invoices with an add_index greater than the specified value. If the
-    settle_index is specified, the next, we'll send out all settle events for
+    settle_index is specified, then next, we'll send out all settle events for
     invoices with a settle_index greater than the specified value. One or both
     of these fields can be set. If no fields are set, then we'll only send out
     the latest add/settle events.
     */
     rpc SubscribeInvoices (InvoiceSubscription) returns (stream Invoice);
+
+    /* lncli: `deletecanceledinvoice`
+    DeleteCanceledInvoice removes a canceled invoice from the database. If the
+    invoice is not in the canceled state, an error will be returned.
+    */
+    rpc DeleteCanceledInvoice (DelCanceledInvoiceReq)
+        returns (DelCanceledInvoiceResp);
 
     /* lncli: `decodepayreq`
     DecodePayReq takes an encoded payment request string and attempts to decode
@@ -341,13 +319,13 @@ service Lightning {
     */
     rpc ListPayments (ListPaymentsRequest) returns (ListPaymentsResponse);
 
-    /*
+    /* lncli: `deletepayments`
     DeletePayment deletes an outgoing payment from DB. Note that it will not
     attempt to delete an In-Flight payment, since that would be unsafe.
     */
     rpc DeletePayment (DeletePaymentRequest) returns (DeletePaymentResponse);
 
-    /*
+    /* lncli: `deletepayments --all`
     DeleteAllPayments deletes all outgoing payments from DB. Note that it will
     not attempt to delete In-Flight payments, since that would be unsafe.
     */
@@ -479,7 +457,7 @@ service Lightning {
     rpc ExportAllChannelBackups (ChanBackupExportRequest)
         returns (ChanBackupSnapshot);
 
-    /*
+    /* lncli: `verifychanbackup`
     VerifyChanBackup allows a caller to verify the integrity of a channel backup
     snapshot. This method will accept either a packed Single or a packed Multi.
     Specifying both will result in an error.
@@ -536,9 +514,10 @@ service Lightning {
         returns (ListPermissionsResponse);
 
     /*
-    CheckMacaroonPermissions checks whether a request follows the constraints
-    imposed on the macaroon and that the macaroon is authorized to follow the
-    provided permissions.
+    CheckMacaroonPermissions checks whether the provided macaroon contains all
+    the provided permissions. If the macaroon is valid (e.g. all caveats are
+    satisfied), and all permissions provided in the request are met, then
+    this RPC returns true.
     */
     rpc CheckMacaroonPermissions (CheckMacPermRequest)
         returns (CheckMacPermResponse);
@@ -576,6 +555,18 @@ service Lightning {
     */
     rpc SubscribeCustomMessages (SubscribeCustomMessagesRequest)
         returns (stream CustomMessage);
+
+    /* lncli: `sendonion`
+    SendOnionMessage sends an onion message to a peer.
+    */
+    rpc SendOnionMessage (SendOnionMessageRequest)
+        returns (SendOnionMessageResponse);
+
+    /* lncli: `subscribeonion`
+    SubscribeOnionMessages subscribes to a stream of incoming onion messages.
+    */
+    rpc SubscribeOnionMessages (SubscribeOnionMessagesRequest)
+        returns (stream OnionMessageUpdate);
 
     /* lncli: `listaliases`
     ListAliases returns the set of all aliases that have ever existed with
@@ -622,7 +613,8 @@ message CustomMessage {
 }
 
 message SendCustomMessageRequest {
-    // Peer to send the message to
+    // Peer to which the message will be sent. Represented as a byte-encoded
+    // public key
     bytes peer = 1;
 
     // Message type. This value needs to be in the custom range (>= 32768).
@@ -636,6 +628,69 @@ message SendCustomMessageRequest {
 }
 
 message SendCustomMessageResponse {
+    // The status of the send operation.
+    string status = 1;
+}
+
+message SubscribeOnionMessagesRequest {
+}
+
+message OnionMessageUpdate {
+    // Peer from which this message originates. Represented as a byte-encoded
+    // public key.
+    bytes peer = 1;
+
+    // PathKey is used to derive the blinded node id by tweaking the hop's
+    // static public key. The hop uses the corresponding blinded private key
+    // together with the sender's ephemeral key to perform ECDH and obtain the
+    // shared secret for decrypting the onion payload. Separately, for
+    // decrypting `encrypted_recipient_data`, the recipient performs ECDH
+    // between its static node private key and the path_key to derive the
+    // decryption key.
+    bytes path_key = 2;
+
+    // Serialized Sphinx onion packet (BOLT 4) containing the layered, per-hop
+    // encrypted payloads and routing instructions used to forward this message
+    // along its designated path.
+    bytes onion = 3;
+
+    // reply_path is the blinded path that should be used when replying to a
+    // received message.
+    BlindedPath reply_path = 4;
+
+    // encrypted_recipient_data is the encrypted data that contains the
+    // forwarding information for an onion message. It contains either
+    // next_node_id or short_channel_id for each non-final node. It MAY contain
+    // the path_id for the final node.
+    bytes encrypted_recipient_data = 5;
+
+    // Custom onion message tlv records. These are customized fields that are
+    // not defined by LND and cannot be extracted.
+    map<uint64, bytes> custom_records = 6;
+}
+
+message SendOnionMessageRequest {
+    // Peer to send the message to
+    bytes peer = 1;
+
+    // PathKey is used to derive the blinded node id by tweaking the hop's
+    // static public key. The hop uses the corresponding blinded private key
+    // together with the sender's ephemeral key to perform ECDH and obtain the
+    // shared secret for decrypting the onion payload. Separately, for
+    // decrypting `encrypted_recipient_data`, the recipient performs ECDH
+    // between its static node private key and the path_key to derive the
+    // decryption key.
+    bytes path_key = 2;
+
+    // Serialized Sphinx onion packet (BOLT 4) containing the layered, per-hop
+    // encrypted payloads and routing instructions used to forward this message
+    // along its designated path.
+    bytes onion = 3;
+}
+
+message SendOnionMessageResponse {
+    // The status of the onion message send operation.
+    string status = 1;
 }
 
 message Utxo {
@@ -748,11 +803,35 @@ message GetTransactionsRequest {
 
     // An optional filter to only include transactions relevant to an account.
     string account = 3;
+
+    /*
+    The index of a transaction that will be used in a query to determine which
+    transaction should be returned in the response.
+    */
+    uint32 index_offset = 4;
+
+    /*
+    The maximal number of transactions returned in the response to this query.
+    This value should be set to 0 to return all transactions.
+    */
+    uint32 max_transactions = 5;
 }
 
 message TransactionDetails {
     // The list of transactions relevant to the wallet.
     repeated Transaction transactions = 1;
+
+    /*
+    The index of the last item in the set of returned transactions. This can be
+    used to seek further, pagination style.
+    */
+    uint64 last_index = 2;
+
+    /*
+    The index of the last item in the set of returned transactions. This can be
+    used to seek backwards, pagination style.
+    */
+    uint64 first_index = 3;
 }
 
 message FeeLimit {
@@ -774,138 +853,6 @@ message FeeLimit {
         // The fee limit expressed as a percentage of the payment amount.
         int64 percent = 2;
     }
-}
-
-message SendRequest {
-    /*
-    The identity pubkey of the payment recipient. When using REST, this field
-    must be encoded as base64.
-    */
-    bytes dest = 1;
-
-    /*
-    The hex-encoded identity pubkey of the payment recipient. Deprecated now
-    that the REST gateway supports base64 encoding of bytes fields.
-    */
-    string dest_string = 2 [deprecated = true];
-
-    /*
-    The amount to send expressed in satoshis.
-
-    The fields amt and amt_msat are mutually exclusive.
-    */
-    int64 amt = 3;
-
-    /*
-    The amount to send expressed in millisatoshis.
-
-    The fields amt and amt_msat are mutually exclusive.
-    */
-    int64 amt_msat = 12;
-
-    /*
-    The hash to use within the payment's HTLC. When using REST, this field
-    must be encoded as base64.
-    */
-    bytes payment_hash = 4;
-
-    /*
-    The hex-encoded hash to use within the payment's HTLC. Deprecated now
-    that the REST gateway supports base64 encoding of bytes fields.
-    */
-    string payment_hash_string = 5 [deprecated = true];
-
-    /*
-    A bare-bones invoice for a payment within the Lightning Network. With the
-    details of the invoice, the sender has all the data necessary to send a
-    payment to the recipient.
-    */
-    string payment_request = 6;
-
-    /*
-    The CLTV delta from the current height that should be used to set the
-    timelock for the final hop.
-    */
-    int32 final_cltv_delta = 7;
-
-    /*
-    The maximum number of satoshis that will be paid as a fee of the payment.
-    This value can be represented either as a percentage of the amount being
-    sent, or as a fixed amount of the maximum fee the user is willing the pay to
-    send the payment. If not specified, lnd will use a default value of 100%
-    fees for small amounts (<=1k sat) or 5% fees for larger amounts.
-    */
-    FeeLimit fee_limit = 8;
-
-    /*
-    The channel id of the channel that must be taken to the first hop. If zero,
-    any channel may be used.
-    */
-    uint64 outgoing_chan_id = 9 [jstype = JS_STRING];
-
-    /*
-    The pubkey of the last hop of the route. If empty, any hop may be used.
-    */
-    bytes last_hop_pubkey = 13;
-
-    /*
-    An optional maximum total time lock for the route. This should not exceed
-    lnd's `--max-cltv-expiry` setting. If zero, then the value of
-    `--max-cltv-expiry` is enforced.
-    */
-    uint32 cltv_limit = 10;
-
-    /*
-    An optional field that can be used to pass an arbitrary set of TLV records
-    to a peer which understands the new records. This can be used to pass
-    application specific data during the payment attempt. Record types are
-    required to be in the custom range >= 65536. When using REST, the values
-    must be encoded as base64.
-    */
-    map<uint64, bytes> dest_custom_records = 11;
-
-    // If set, circular payments to self are permitted.
-    bool allow_self_payment = 14;
-
-    /*
-    Features assumed to be supported by the final node. All transitive feature
-    dependencies must also be set properly. For a given feature bit pair, either
-    optional or remote may be set, but not both. If this field is nil or empty,
-    the router will try to load destination features from the graph as a
-    fallback.
-    */
-    repeated FeatureBit dest_features = 15;
-
-    /*
-    The payment address of the generated invoice.
-    */
-    bytes payment_addr = 16;
-}
-
-message SendResponse {
-    string payment_error = 1;
-    bytes payment_preimage = 2;
-    Route payment_route = 3;
-    bytes payment_hash = 4;
-}
-
-message SendToRouteRequest {
-    /*
-    The payment hash to use for the HTLC. When using REST, this field must be
-    encoded as base64.
-    */
-    bytes payment_hash = 1;
-
-    /*
-    An optional hex-encoded payment hash to be used for the HTLC. Deprecated now
-    that the REST gateway supports base64 encoding of bytes fields.
-    */
-    string payment_hash_string = 2 [deprecated = true];
-
-    reserved 3;
-
-    // Route that should be used to attempt to complete the payment.
-    Route route = 4;
 }
 
 message ChannelAcceptRequest {
@@ -1083,6 +1030,18 @@ message LightningAddress {
     string host = 2;
 }
 
+enum CoinSelectionStrategy {
+    // Use the coin selection strategy defined in the global configuration
+    // (lnd.conf).
+    STRATEGY_USE_GLOBAL_CONFIG = 0;
+
+    // Select the largest available coins first during coin selection.
+    STRATEGY_LARGEST = 1;
+
+    // Randomly select the available coins during coin selection.
+    STRATEGY_RANDOM = 2;
+}
+
 message EstimateFeeRequest {
     // The map from addresses to amounts for the transaction.
     map<string, int64> AddrToAmount = 1;
@@ -1097,6 +1056,12 @@ message EstimateFeeRequest {
 
     // Whether unconfirmed outputs should be used as inputs for the transaction.
     bool spend_unconfirmed = 4;
+
+    // The strategy to use for selecting coins during fees estimation.
+    CoinSelectionStrategy coin_selection_strategy = 5;
+
+    // A list of selected inputs for the transaction.
+    repeated OutPoint inputs = 6;
 }
 
 message EstimateFeeResponse {
@@ -1109,6 +1074,9 @@ message EstimateFeeResponse {
 
     // The fee rate in satoshi/vbyte.
     uint64 sat_per_vbyte = 3;
+
+    // A list of selected inputs for the transaction the estimate is for.
+    repeated OutPoint inputs = 4;
 }
 
 message SendManyRequest {
@@ -1137,6 +1105,9 @@ message SendManyRequest {
 
     // Whether unconfirmed outputs should be used as inputs for the transaction.
     bool spend_unconfirmed = 8;
+
+    // The strategy to use for selecting coins during sending many requests.
+    CoinSelectionStrategy coin_selection_strategy = 9;
 }
 message SendManyResponse {
     // The id of the transaction
@@ -1164,9 +1135,8 @@ message SendCoinsRequest {
     int64 sat_per_byte = 5 [deprecated = true];
 
     /*
-    If set, then the amount field will be ignored, and lnd will attempt to
-    send all the coins under control of the internal wallet to the specified
-    address.
+    If set, the amount field should be unset. It indicates lnd will send all
+    wallet coins or all selected coins to the specified address.
     */
     bool send_all = 6;
 
@@ -1179,6 +1149,12 @@ message SendCoinsRequest {
 
     // Whether unconfirmed outputs should be used as inputs for the transaction.
     bool spend_unconfirmed = 9;
+
+    // The strategy to use for selecting coins.
+    CoinSelectionStrategy coin_selection_strategy = 10;
+
+    // A list of selected outpoints as inputs for the transaction.
+    repeated OutPoint outpoints = 11;
 }
 message SendCoinsResponse {
     // The transaction ID of the transaction
@@ -1286,6 +1262,8 @@ message ConnectPeerRequest {
     uint64 timeout = 3;
 }
 message ConnectPeerResponse {
+    // The status of the connect operation.
+    string status = 1;
 }
 
 message DisconnectPeerRequest {
@@ -1293,6 +1271,8 @@ message DisconnectPeerRequest {
     string pub_key = 1;
 }
 message DisconnectPeerResponse {
+    // The status of the disconnect operation.
+    string status = 1;
 }
 
 message HTLC {
@@ -1315,9 +1295,21 @@ message HTLC {
 
     // Index identifying the htlc on the forwarding channel.
     uint64 forwarding_htlc_index = 7;
+
+    /*
+    Whether the HTLC is locked in. An HTLC is considered locked in when the
+    remote party has sent us the `revoke_and_ack` to irrevocably commit this
+    HTLC.
+    */
+    bool locked_in = 8;
 }
 
 enum CommitmentType {
+    // Allow multiple enum names to map to the same numeric value so the
+    // taproot channel types can expose short, canonical aliases without
+    // breaking on-wire compatibility with the historic names.
+    option allow_alias = true;
+
     /*
     Returned when the commitment type isn't known or unavailable.
     */
@@ -1354,11 +1346,34 @@ enum CommitmentType {
     SCRIPT_ENFORCED_LEASE = 4;
 
     /*
-    A channel that uses musig2 for the funding output, and the new tapscript
-    features where relevant.
+    The production taproot channel type that uses musig2 for the funding
+    output and the new tapscript features, with final scripts and feature
+    bits 80/81. This is the recommended taproot variant; new integrations
+    should select this enum value.
     */
-    // TODO(roasbeef): need script enforce mirror type for the above as well?
+    TAPROOT = 7;
+
+    /*
+    Deprecated alias for TAPROOT, preserved so existing clients that select
+    the production taproot channel type by its historic name continue to
+    compile and serialize against the same wire value.
+    */
+    SIMPLE_TAPROOT_FINAL = 7;
+
+    /*
+    A legacy taproot channel type that uses musig2 for the funding output and
+    the new tapscript features, but with development scripts and the staging
+    feature bits. Retained for compatibility with peers that have not upgraded
+    to TAPROOT; new integrations should prefer TAPROOT.
+    */
     SIMPLE_TAPROOT = 5;
+
+    /*
+    Identical to the SIMPLE_TAPROOT channel type, but with extra functionality.
+    This channel type also commits to additional meta data in the tapscript
+    leaves for the scripts in a channel.
+    */
+    SIMPLE_TAPROOT_OVERLAY = 6;
 }
 
 message ChannelConstraints {
@@ -1561,6 +1576,11 @@ message Channel {
     the channel's operation.
     */
     string memo = 36;
+
+    /*
+    Custom channel data that might be populated in custom channels.
+    */
+    bytes custom_channel_data = 37;
 }
 
 message ListChannelsRequest {
@@ -1674,6 +1694,10 @@ message ChannelCloseSummary {
 
     //  The confirmed SCID for a zero-conf channel.
     uint64 zero_conf_confirmed_scid = 15 [jstype = JS_STRING];
+
+    // The TLV encoded custom channel data records for this output, which might
+    // be set for custom channels.
+    bytes custom_channel_data = 16;
 }
 
 enum ResolutionType {
@@ -1823,6 +1847,7 @@ message Peer {
     repeated TimestampedError errors = 12;
 
     /*
+    This field is populated when the peer has at least one channel with us.
     The number of times we have recorded this peer going offline or coming
     online, recorded across restarts. Note that this value is decreased over
     time if the peer has not recently flapped, so that we can forgive peers
@@ -1831,6 +1856,7 @@ message Peer {
     int32 flap_count = 13;
 
     /*
+    This field is populated when the peer has at least one channel with us.
     The timestamp of the last flap we observed for this peer. If this value is
     zero, we have not observed any flaps for this peer.
     */
@@ -1880,6 +1906,13 @@ message PeerEvent {
 
 message GetInfoRequest {
 }
+enum GraphCacheStatus {
+    GRAPH_CACHE_STATUS_DISABLED = 0;
+    GRAPH_CACHE_STATUS_LOADING = 1;
+    GRAPH_CACHE_STATUS_LOADED = 2;
+    GRAPH_CACHE_STATUS_FAILED = 3;
+}
+
 message GetInfoResponse {
     // The version of the LND software that the node is running.
     string version = 14;
@@ -1924,14 +1957,18 @@ message GetInfoResponse {
     bool synced_to_graph = 18;
 
     /*
-    Whether the current node is connected to testnet. This field is
-    deprecated and the network field should be used instead
-    **/
+    Whether the current node is connected to testnet or testnet4. This field is
+    deprecated and the network field should be used instead.
+    */
     bool testnet = 10 [deprecated = true];
 
     reserved 11;
 
-    // A list of active chains the node is connected to
+    /*
+    A list of active chains the node is connected to. This will only
+    ever contain a single entry since LND will only ever have a single
+    chain backend during its lifetime.
+    */
     repeated Chain chains = 16;
 
     // The URIs of the current node.
@@ -1950,6 +1987,24 @@ message GetInfoResponse {
 
     // Indicates whether final htlc resolutions are stored on disk.
     bool store_final_htlc_resolutions = 22;
+
+    // Whether the wallet is fully synced to the best chain. This indicates the
+    // wallet's internal sync state with the backing chain source.
+    bool wallet_synced = 23;
+
+    // The current status of the in-memory graph cache.
+    GraphCacheStatus graph_cache_status = 24;
+}
+
+message GetDebugInfoRequest {
+    // If set to true, the log file content will be included in the response.
+    // By default, only the config information is returned.
+    bool include_log = 1;
+}
+
+message GetDebugInfoResponse {
+    map<string, string> config = 1;
+    repeated string log = 2;
 }
 
 message GetRecoveryInfoRequest {
@@ -1966,28 +2021,50 @@ message GetRecoveryInfoResponse {
 }
 
 message Chain {
-    // The blockchain the node is on (eg bitcoin, litecoin)
-    string chain = 1;
+    // Deprecated. The chain is now always assumed to be bitcoin.
+    // The blockchain the node is on (must be bitcoin)
+    string chain = 1 [deprecated = true];
 
     // The network the node is on (eg regtest, testnet, mainnet)
     string network = 2;
-}
-
-message ConfirmationUpdate {
-    bytes block_sha = 1;
-    int32 block_height = 2;
-
-    uint32 num_confs_left = 3;
 }
 
 message ChannelOpenUpdate {
     ChannelPoint channel_point = 1;
 }
 
+message CloseOutput {
+    // The amount in satoshi of this close output. This amount is the final
+    // commitment balance of the channel and the actual amount paid out on chain
+    // might be smaller due to subtracted fees.
+    int64 amount_sat = 1;
+
+    // The pkScript of the close output.
+    bytes pk_script = 2;
+
+    // Whether this output is for the local or remote node.
+    bool is_local = 3;
+
+    // The TLV encoded custom channel data records for this output, which might
+    // be set for custom channels.
+    bytes custom_channel_data = 4;
+}
+
 message ChannelCloseUpdate {
     bytes closing_txid = 1;
 
     bool success = 2;
+
+    // The local channel close output. If the local channel balance was dust to
+    // begin with, this output will not be set.
+    CloseOutput local_close_output = 3;
+
+    // The remote channel close output. If the remote channel balance was dust
+    // to begin with, this output will not be set.
+    CloseOutput remote_close_output = 4;
+
+    // Any additional outputs that might be added for custom channel types.
+    repeated CloseOutput additional_outputs = 5;
 }
 
 message CloseChannelRequest {
@@ -2027,18 +2104,37 @@ message CloseChannelRequest {
     //
     // NOTE: This field is only respected if we're the initiator of the channel.
     uint64 max_fee_per_vbyte = 7;
+
+    // If true, then the rpc call will not block while it awaits a closing txid
+    // to be broadcasted to the mempool. To obtain the closing tx one has to
+    // listen to the stream for the particular updates. Moreover if a coop close
+    // is specified and this flag is set to true the coop closing flow will be
+    // initiated even if HTLCs are active on the channel. The channel will wait
+    // until all HTLCs are resolved and then start the coop closing process. The
+    // channel will be disabled in the meantime and will disallow any new HTLCs.
+    bool no_wait = 8;
 }
 
 message CloseStatusUpdate {
     oneof update {
         PendingUpdate close_pending = 1;
         ChannelCloseUpdate chan_close = 3;
+        InstantUpdate close_instant = 4;
     }
 }
 
 message PendingUpdate {
     bytes txid = 1;
     uint32 output_index = 2;
+    int64 fee_per_vbyte = 3;
+    bool local_close_tx = 4;
+}
+
+message InstantUpdate {
+    // The number of pending HTLCs that are currently active on the channel.
+    // These HTLCs need to be resolved before the channel can be closed
+    // cooperatively.
+    int32 num_pending_htlcs = 1;
 }
 
 message ReadyForPsbtFunding {
@@ -2085,6 +2181,9 @@ message BatchOpenChannelRequest {
 
     // An optional label for the batch transaction, limited to 500 characters.
     string label = 6;
+
+    // The strategy to use for selecting coins during batch opening channels.
+    CoinSelectionStrategy coin_selection_strategy = 7;
 }
 
 message BatchOpenChannel {
@@ -2608,6 +2707,9 @@ message PendingHTLC {
 }
 
 message PendingChannelsRequest {
+    // Indicates whether to include the raw transaction hex for
+    // waiting_close_channels.
+    bool include_raw_tx = 1;
 }
 message PendingChannelsResponse {
     message PendingChannel {
@@ -2650,6 +2752,11 @@ message PendingChannelsResponse {
         impacts the channel's operation.
         */
         string memo = 13;
+
+        /*
+        Custom channel data that might be populated in custom channels.
+        */
+        bytes custom_channel_data = 34;
     }
 
     message PendingOpenChannel {
@@ -2688,6 +2795,25 @@ message PendingChannelsResponse {
         // very likely canceled the funding and the channel will never become
         // fully operational.
         int32 funding_expiry_blocks = 3;
+
+        // The number of blocks remaining until the channel status changes from
+        // pending to active. A value of 0 indicates that the channel is now
+        // active.
+        //
+        // "Active" here means both channel peers have the channel marked OPEN
+        // and can immediately start using it. For public channels, this does
+        // not imply a channel_announcement has been gossiped. It only becomes
+        // public on the network after 6 on‐chain confirmations.
+        // See BOLT07 "Routing Gossip":
+        // https://github.com/lightning/bolts/blob/master/07-routing-gossip.md
+        //
+        // ZeroConf channels bypass the pending state entirely: they are marked
+        // active immediately upon creation, so they never show up as "pending".
+        uint32 confirmations_until_active = 7;
+
+        // The confirmation height records the block height at which the funding
+        // transaction was first confirmed.
+        uint32 confirmation_height = 8;
     }
 
     message WaitingCloseChannel {
@@ -2705,6 +2831,28 @@ message PendingChannelsResponse {
 
         // The transaction id of the closing transaction
         string closing_txid = 4;
+
+        // The raw hex encoded bytes of the closing transaction. Included if
+        // include_raw_tx in the request is true.
+        string closing_tx_hex = 5;
+
+        /*
+        Remaining number of confirmations until the channel closure is
+        considered final and removed from waiting close. Channel closes
+        require multiple confirmations for reorg protection — the exact
+        number scales with channel capacity. A closing transaction that
+        gets reorganized out of the chain resets this counter. When the
+        closing transaction is not yet confirmed, this value equals the
+        total number of confirmations required.
+        */
+        uint32 blocks_til_close_confirmed = 6;
+
+        /*
+        The block height at which the closing transaction was first confirmed.
+        This will be zero if the closing transaction has not yet confirmed, or
+        if this information is not available for older channels.
+        */
+        uint32 close_height = 7;
     }
 
     message Commitments {
@@ -2809,6 +2957,10 @@ message PendingChannelsResponse {
 message ChannelEventSubscription {
 }
 
+message ChannelCommitUpdate {
+    Channel channel = 1;
+}
+
 message ChannelEventUpdate {
     oneof channel {
         Channel open_channel = 1;
@@ -2817,6 +2969,8 @@ message ChannelEventUpdate {
         ChannelPoint inactive_channel = 4;
         PendingUpdate pending_open_channel = 6;
         ChannelPoint fully_resolved_channel = 7;
+        ChannelPoint channel_funding_timeout = 8;
+        ChannelCommitUpdate updated_channel = 9;
     }
 
     enum UpdateType {
@@ -2826,6 +2980,8 @@ message ChannelEventUpdate {
         INACTIVE_CHANNEL = 3;
         PENDING_OPEN_CHANNEL = 4;
         FULLY_RESOLVED_CHANNEL = 5;
+        CHANNEL_FUNDING_TIMEOUT = 6;
+        CHANNEL_UPDATE = 7;
     }
 
     UpdateType type = 5;
@@ -2843,6 +2999,11 @@ message WalletBalanceRequest {
     // The wallet account the balance is shown for.
     // If this is not specified, the balance of the "default" account is shown.
     string account = 1;
+
+    // The minimum number of confirmations each one of your outputs used for the
+    // funding transaction must satisfy. If this is not specified, the default
+    // value of 1 is used.
+    int32 min_confs = 2;
 }
 
 message WalletBalanceResponse {
@@ -2900,6 +3061,12 @@ message ChannelBalanceResponse {
 
     // Sum of channels pending remote balances.
     Amount pending_open_remote_balance = 8;
+
+    /*
+    Custom channel data that might be populated if there are custom channels
+    present.
+    */
+    bytes custom_channel_data = 9;
 }
 
 message QueryRoutesRequest {
@@ -2928,6 +3095,9 @@ message QueryRoutesRequest {
     not add any additional block padding on top of final_ctlv_delta. This
     padding of a few blocks needs to be added manually or otherwise failures may
     happen when a block comes in while the payment is in flight.
+
+    Note: must not be set if making a payment to a blinded path (delta is
+    set by the aggregate parameters provided by blinded_payment_paths)
     */
     int32 final_cltv_delta = 4;
 
@@ -2985,11 +3155,7 @@ message QueryRoutesRequest {
     */
     map<uint64, bytes> dest_custom_records = 13;
 
-    /*
-    The channel id of the channel that must be taken to the first hop. If zero,
-    any channel may be used.
-    */
-    uint64 outgoing_chan_id = 14 [jstype = JS_STRING];
+    reserved 14;
 
     /*
     The pubkey of the last hop of the route. If empty, any hop may be used.
@@ -3002,11 +3168,20 @@ message QueryRoutesRequest {
     repeated lnrpc.RouteHint route_hints = 16;
 
     /*
+    An optional blinded path(s) to reach the destination. Note that the
+    introduction node must be provided as the first hop in the route.
+    */
+    repeated BlindedPaymentPath blinded_payment_paths = 19;
+
+    /*
     Features assumed to be supported by the final node. All transitive feature
     dependencies must also be set properly. For a given feature bit pair, either
     optional or remote may be set, but not both. If this field is nil or empty,
     the router will try to load destination features from the graph as a
     fallback.
+
+    Note: must not be set if making a payment to a blinded route (features
+    are provided in blinded_payment_paths).
     */
     repeated lnrpc.FeatureBit dest_features = 17;
 
@@ -3015,6 +3190,12 @@ message QueryRoutesRequest {
     only, to 1 to optimize for reliability only or a value inbetween for a mix.
     */
     double time_pref = 18;
+
+    /*
+    The channel ids of the channels allowed for the first hop. If empty, any
+    channel may be used.
+    */
+    repeated uint64 outgoing_chan_ids = 20;
 }
 
 message NodePair {
@@ -3112,6 +3293,32 @@ message Hop {
 
     // The payment metadata to send along with the payment to the payee.
     bytes metadata = 13;
+
+    /*
+    Blinding point is an optional blinding point included for introduction
+    nodes in blinded paths. This field is mandatory for hops that represents
+    the introduction point in a blinded path.
+    */
+    bytes blinding_point = 14;
+
+    /*
+    Encrypted data is a receiver-produced blob of data that provides hops
+    in a blinded route with forwarding data. As this data is encrypted by
+    the recipient, we will not be able to parse it - it is essentially an
+    arbitrary blob of data from our node's perspective. This field is
+    mandatory for all hops in a blinded path, including the introduction
+    node.
+    */
+    bytes encrypted_data = 15;
+
+    /*
+    The total amount that is sent to the recipient (possibly across multiple
+    HTLCs), as specified by the sender when making a payment to a blinded path.
+    This value is only set in the final hop payload of a blinded payment. This
+    value is analogous to the MPPRecord that is used for regular (non-blinded)
+    MPP payments.
+    */
+    uint64 total_amt_msat = 16;
 }
 
 message MPPRecord {
@@ -3119,7 +3326,8 @@ message MPPRecord {
     A unique, random identifier used to authenticate the sender as the intended
     payer of a multi-path payment. The payment_addr must be the same for all
     subpayments, and match the payment_addr provided in the receiver's invoice.
-    The same payment_addr must be used on all subpayments.
+    The same payment_addr must be used on all subpayments. This is also called
+    payment secret in specifications (e.g. BOLT 11).
     */
     bytes payment_addr = 11;
 
@@ -3186,6 +3394,20 @@ message Route {
     The total amount in millisatoshis.
     */
     int64 total_amt_msat = 6;
+
+    /*
+    The actual on-chain amount that was sent out to the first hop. This value is
+    only different from the total_amt_msat field if this is a custom channel
+    payment and the value transported in the HTLC is different from the BTC
+    amount in the HTLC. If this value is zero, then this is an old payment that
+    didn't have this value yet and can be ignored.
+    */
+    int64 first_hop_amount_msat = 7;
+
+    /*
+    Custom channel data that might be populated in custom channels.
+    */
+    bytes custom_channel_data = 8;
 }
 
 message NodeInfoRequest {
@@ -3194,6 +3416,10 @@ message NodeInfoRequest {
 
     // If true, will include all known channels associated with the node.
     bool include_channels = 2;
+
+    // If true, will include announcements' signatures into ChannelEdge.
+    // Depends on include_channels.
+    bool include_auth_proof = 3;
 }
 
 message NodeInfo {
@@ -3247,8 +3473,37 @@ message RoutingPolicy {
     uint64 max_htlc_msat = 6;
     uint32 last_update = 7;
 
-    // Custom channel update tlv records.
+    // Custom channel update tlv records. These are customized fields that are
+    // not defined by LND and cannot be extracted.
     map<uint64, bytes> custom_records = 8;
+
+    int32 inbound_fee_base_msat = 9;
+    int32 inbound_fee_rate_milli_msat = 10;
+}
+
+/*
+ChannelAuthProof is the authentication proof (the signature portion) for a
+channel. Using the four signatures contained in the struct, and some
+auxiliary knowledge (the funding script, node identities, and outpoint) nodes
+on the network are able to validate the authenticity and existence of a
+channel.
+*/
+message ChannelAuthProof {
+    // node_sig1 are the raw bytes of the first node signature encoded
+    // in DER format.
+    bytes node_sig1 = 1;
+
+    // bitcoin_sig1 are the raw bytes of the first bitcoin signature of the
+    // MultiSigKey key of the channel encoded in DER format.
+    bytes bitcoin_sig1 = 2;
+
+    // node_sig2 are the raw bytes of the second node signature encoded
+    // in DER format.
+    bytes node_sig2 = 3;
+
+    // bitcoin_sig2 are the raw bytes of the second bitcoin signature of the
+    // MultiSigKey key of the channel encoded in DER format.
+    bytes bitcoin_sig2 = 4;
 }
 
 /*
@@ -3279,6 +3534,13 @@ message ChannelEdge {
 
     // Custom channel announcement tlv records.
     map<uint64, bytes> custom_records = 9;
+
+    // Authentication proof for this channel. This proof contains a set of
+    // signatures binding four identities, which attests to the legitimacy of
+    // the advertised channel. This only is available for advertised channels.
+    // This field is not filled by default. Pass include_auth_proof flag to
+    // DescribeGraph, GetNodeInfo or GetChanInfo to get this data.
+    ChannelAuthProof auth_proof = 10;
 }
 
 message ChannelGraphRequest {
@@ -3288,6 +3550,9 @@ message ChannelGraphRequest {
     channels, and public channels that are not yet announced to the network.
     */
     bool include_unannounced = 1;
+
+    // If true, will include announcements' signatures into ChannelEdge.
+    bool include_auth_proof = 2;
 }
 
 // Returns a new instance of the directed channel graph.
@@ -3335,6 +3600,13 @@ message ChanInfoRequest {
     output index for the channel.
     */
     uint64 chan_id = 1 [jstype = JS_STRING];
+
+    // The channel point of the channel in format funding_txid:output_index. If
+    // chan_id is specified, this field is ignored.
+    string chan_point = 2;
+
+    // If true, will include announcements' signatures into ChannelEdge.
+    bool include_auth_proof = 3;
 }
 
 message NetworkInfoRequest {
@@ -3364,6 +3636,8 @@ message NetworkInfo {
 message StopRequest {
 }
 message StopResponse {
+    // The status of the stop operation.
+    string status = 1;
 }
 
 message GraphTopologySubscription {
@@ -3455,6 +3729,64 @@ message RouteHint {
     specific destination.
     */
     repeated HopHint hop_hints = 1;
+}
+
+message BlindedPaymentPath {
+    // The blinded path to send the payment to.
+    BlindedPath blinded_path = 1;
+
+    // The base fee for the blinded path provided, expressed in msat.
+    uint64 base_fee_msat = 2;
+
+    /*
+    The proportional fee for the blinded path provided, expressed in parts
+    per million.
+    */
+    uint32 proportional_fee_rate = 3;
+
+    /*
+    The total CLTV delta for the blinded path provided, including the
+    final CLTV delta for the receiving node.
+    */
+    uint32 total_cltv_delta = 4;
+
+    /*
+    The minimum hltc size that may be sent over the blinded path, expressed
+    in msat.
+    */
+    uint64 htlc_min_msat = 5;
+
+    /*
+    The maximum htlc size that may be sent over the blinded path, expressed
+    in msat.
+    */
+    uint64 htlc_max_msat = 6;
+
+    // The feature bits for the route.
+    repeated FeatureBit features = 7;
+}
+
+message BlindedPath {
+    // The unblinded pubkey of the introduction node for the route.
+    bytes introduction_node = 1;
+
+    // The ephemeral pubkey used by nodes in the blinded route.
+    bytes blinding_point = 2;
+
+    /*
+    A set of blinded node keys and data blobs for the blinded portion of the
+    route. Note that the first hop is expected to be the introduction node,
+    so the route is always expected to have at least one hop.
+    */
+    repeated BlindedHop blinded_hops = 3;
+}
+
+message BlindedHop {
+    // The blinded public key of the node.
+    bytes blinded_node = 1;
+
+    // An encrypted blob of data provided to the blinded node.
+    bytes encrypted_data = 2;
 }
 
 message AMPInvoiceState {
@@ -3643,9 +3975,10 @@ message Invoice {
     bool is_keysend = 25;
 
     /*
-    The payment address of this invoice. This value will be used in MPP
-    payments, and also for newer invoices that always require the MPP payload
-    for added end-to-end security.
+    The payment address of this invoice. This is also called payment secret in
+    specifications (e.g. BOLT 11). This value will be used in MPP payments, and
+    also for newer invoices that always require the MPP payload for added
+    end-to-end security.
     Note: Output only, don't specify for creating an invoice.
     */
     bytes payment_addr = 26;
@@ -3665,6 +3998,54 @@ message Invoice {
     Note: Output only, don't specify for creating an invoice.
     */
     map<string, AMPInvoiceState> amp_invoice_state = 28;
+
+    /*
+    Signals that the invoice should include blinded paths to hide the true
+    identity of the recipient.
+    */
+    bool is_blinded = 29;
+
+    /*
+    Config values to use when creating blinded paths for this invoice. These
+    can be used to override the defaults config values provided in by the
+    global config. This field is only used if is_blinded is true.
+    */
+    BlindedPathConfig blinded_path_config = 30;
+}
+
+message BlindedPathConfig {
+    /*
+    The minimum number of real hops to include in a blinded path. This doesn't
+    include our node, so if the minimum is 1, then the path will contain at
+    minimum our node along with an introduction node hop. If it is zero then
+    the shortest path will use our node as an introduction node.
+    */
+    optional uint32 min_num_real_hops = 1;
+
+    /*
+    The number of hops to include in a blinded path. This doesn't include our
+    node, so if it is 1, then the path will contain our node along with an
+    introduction node or dummy node hop. If paths shorter than NumHops is
+    found, then they will be padded using dummy hops.
+    */
+    optional uint32 num_hops = 2;
+
+    /*
+    The maximum number of blinded paths to select and add to an invoice.
+    */
+    optional uint32 max_num_paths = 3;
+
+    /*
+    A list of node IDs of nodes that should not be used in any of our generated
+    blinded paths.
+    */
+    repeated bytes node_omission_list = 4;
+
+    /*
+    The chained channels list specified via channel id (separated by commas),
+    starting from a channel owned by the receiver node.
+    */
+    repeated uint64 incoming_channel_list = 5;
 }
 
 enum InvoiceHTLCState {
@@ -3707,6 +4088,11 @@ message InvoiceHTLC {
 
     // Details relevant to AMP HTLCs, only populated if this is an AMP HTLC.
     AMP amp = 11;
+
+    /*
+    Custom channel data that might be populated in custom channels.
+    */
+    bytes custom_channel_data = 12;
 }
 
 // Details specific to AMP HTLCs.
@@ -3750,9 +4136,9 @@ message AddInvoiceResponse {
     uint64 add_index = 16;
 
     /*
-    The payment address of the generated invoice. This value should be used
-    in all payments for this invoice as we require it for end to end
-    security.
+    The payment address of the generated invoice. This is also called
+    payment secret in specifications (e.g. BOLT 11). This value should be used
+    in all payments for this invoice as we require it for end to end security.
     */
     bytes payment_addr = 17;
 }
@@ -3841,6 +4227,16 @@ message InvoiceSubscription {
     uint64 settle_index = 2;
 }
 
+message DelCanceledInvoiceReq {
+    // Invoice payment hash to delete.
+    string invoice_hash = 1;
+}
+
+message DelCanceledInvoiceResp {
+    // The status of the delete operation.
+    string status = 1;
+}
+
 enum PaymentFailureReason {
     /*
     Payment isn't failed (yet).
@@ -3873,6 +4269,11 @@ enum PaymentFailureReason {
     Insufficient local balance.
     */
     FAILURE_REASON_INSUFFICIENT_BALANCE = 5;
+
+    /*
+    The payment was canceled.
+    */
+    FAILURE_REASON_CANCELED = 6;
 }
 
 message Payment {
@@ -3903,10 +4304,20 @@ message Payment {
     string payment_request = 9;
 
     enum PaymentStatus {
-        UNKNOWN = 0;
+        // Deprecated. This status will never be returned.
+        UNKNOWN = 0 [deprecated = true];
+
+        // Payment has inflight HTLCs.
         IN_FLIGHT = 1;
+
+        // Payment is settled.
         SUCCEEDED = 2;
+
+        // Payment is failed.
         FAILED = 3;
+
+        // Payment is created and has not attempted any HTLCs.
+        INITIATED = 4;
     }
 
     // The status of the payment.
@@ -3932,6 +4343,12 @@ message Payment {
     uint64 payment_index = 15;
 
     PaymentFailureReason failure_reason = 16;
+
+    /*
+    The custom TLV records that were sent to the first hop as part of the HTLC
+    wire message for this payment.
+    */
+    map<uint64, bytes> first_hop_custom_records = 17;
 }
 
 message HTLCAttempt {
@@ -4002,13 +4419,17 @@ message ListPaymentsRequest {
     */
     bool count_total_payments = 5;
 
-    // If set, returns all invoices with a creation date greater than or equal
+    // If set, returns all payments with a creation date greater than or equal
     // to it. Measured in seconds since the unix epoch.
     uint64 creation_date_start = 6;
 
-    // If set, returns all invoices with a creation date less than or equal to
+    // If set, returns all payments with a creation date less than or equal to
     // it. Measured in seconds since the unix epoch.
     uint64 creation_date_end = 7;
+
+    // If set, omit hop-level route data for HTLC attempts to reduce query
+    // cost and response size.
+    bool omit_hops = 8;
 }
 
 message ListPaymentsResponse {
@@ -4054,12 +4475,20 @@ message DeleteAllPaymentsRequest {
     Only delete failed HTLCs from payments, not the payment itself.
     */
     bool failed_htlcs_only = 2;
+
+    // Delete all payments. NOTE: Using this option requires careful
+    // consideration as it is a destructive operation.
+    bool all_payments = 3;
 }
 
 message DeletePaymentResponse {
+    // The status of the delete operation.
+    string status = 1;
 }
 
 message DeleteAllPaymentsResponse {
+    // The status of the delete operation.
+    string status = 1;
 }
 
 message AbandonChannelRequest {
@@ -4076,6 +4505,8 @@ message AbandonChannelRequest {
 }
 
 message AbandonChannelResponse {
+    // The status of the abandon operation.
+    string status = 1;
 }
 
 message DebugLevelRequest {
@@ -4104,6 +4535,7 @@ message PayReq {
     bytes payment_addr = 11;
     int64 num_msat = 12;
     map<uint32, Feature> features = 13;
+    repeated BlindedPaymentPath blinded_paths = 14;
 }
 
 enum FeatureBit {
@@ -4130,6 +4562,8 @@ enum FeatureBit {
     ANCHORS_OPT = 21;
     ANCHORS_ZERO_FEE_HTLC_REQ = 22;
     ANCHORS_ZERO_FEE_HTLC_OPT = 23;
+    ROUTE_BLINDING_REQUIRED = 24;
+    ROUTE_BLINDING_OPTIONAL = 25;
     AMP_REQ = 30;
     AMP_OPT = 31;
 }
@@ -4159,7 +4593,15 @@ message ChannelFeeReport {
     // The effective fee rate in milli-satoshis. Computed by dividing the
     // fee_per_mil value by 1 million.
     double fee_rate = 4;
+
+    // The base fee charged regardless of the number of milli-satoshis sent.
+    int32 inbound_base_fee_msat = 6;
+
+    // The amount charged per milli-satoshis transferred expressed in
+    // millionths of a satoshi.
+    int32 inbound_fee_per_mil = 7;
 }
+
 message FeeReportResponse {
     // An array of channel fee reports which describes the current fee schedule
     // for each channel.
@@ -4176,6 +4618,16 @@ message FeeReportResponse {
     // The total amount of fee revenue (in satoshis) the switch has collected
     // over the past 1 month.
     uint64 month_fee_sum = 4;
+}
+
+message InboundFee {
+    // The inbound base fee charged regardless of the number of milli-satoshis
+    // received in the channel. By default, only negative values are accepted.
+    int32 base_fee_msat = 1;
+
+    // The effective inbound fee rate in micro-satoshis (parts per million).
+    // By default, only negative values are accepted.
+    int32 fee_rate_ppm = 2;
 }
 
 message PolicyUpdateRequest {
@@ -4210,7 +4662,21 @@ message PolicyUpdateRequest {
 
     // If true, min_htlc_msat is applied.
     bool min_htlc_msat_specified = 8;
+
+    // Optional inbound fee. If unset, the previously set value will be
+    // retained [EXPERIMENTAL].
+    InboundFee inbound_fee = 10;
+
+    // Under unknown circumstances a channel can exist with a missing edge in
+    // the graph database. This can cause an 'edge not found' error when calling
+    // `getchaninfo` and/or cause the default channel policy to be used during
+    // forwards. Setting this flag will recreate the edge if not found, allowing
+    // updating this channel policy and fixing the missing edge problem for this
+    // channel permanently. For fields not set in this command, the default
+    // policy will be created.
+    bool create_missing_edge = 11;
 }
+
 enum UpdateFailure {
     UPDATE_FAILURE_UNKNOWN = 0;
     UPDATE_FAILURE_PENDING = 1;
@@ -4257,6 +4723,14 @@ message ForwardingHistoryRequest {
     // Informs the server if the peer alias should be looked up for each
     // forwarding event.
     bool peer_alias_lookup = 5;
+
+    // List of incoming channel ids to filter htlcs received from a
+    // particular channel
+    repeated uint64 incoming_chan_ids = 6;
+
+    // List of outgoing channel ids to filter htlcs being forwarded to a
+    // particular channel
+    repeated uint64 outgoing_chan_ids = 7;
 }
 message ForwardingEvent {
     // Timestamp is the time (unix epoch offset) that this circuit was
@@ -4301,6 +4775,14 @@ message ForwardingEvent {
 
     // The peer alias of the outgoing channel.
     string peer_alias_out = 13;
+
+    // The ID of the incoming HTLC in the payment circuit. This field is
+    // optional and is unset for forwarding events happened before v0.20.
+    optional uint64 incoming_htlc_id = 14;
+
+    // The ID of the outgoing HTLC in the payment circuit. This field is
+    // optional and may be unset for legacy forwarding events.
+    optional uint64 outgoing_htlc_id = 15;
 
     // TODO(roasbeef): add settlement latency?
     //  * use FPE on the chan id?
@@ -4389,12 +4871,15 @@ message RestoreChanBackupRequest {
     }
 }
 message RestoreBackupResponse {
+    // The number of channels successfully restored.
+    uint32 num_restored = 1;
 }
 
 message ChannelBackupSubscription {
 }
 
 message VerifyChanBackupResponse {
+    repeated string chan_points = 1;
 }
 
 message MacaroonPermission {
@@ -4486,6 +4971,7 @@ message Failure {
         EXPIRY_TOO_FAR = 22;
         MPP_TIMEOUT = 23;
         INVALID_ONION_PAYLOAD = 24;
+        INVALID_ONION_BLINDING = 25;
 
         /*
         An internal error occurred.
@@ -4629,9 +5115,37 @@ message Op {
 }
 
 message CheckMacPermRequest {
+    // The macaroon to check permissions for, serialized in binary format. For
+    // a macaroon to be valid, it must have been issued by lnd, must succeed all
+    // caveat conditions, and must contain all of the permissions specified in
+    // the permissions field.
     bytes macaroon = 1;
+
+    // The list of permissions the macaroon should be checked against. Only if
+    // the macaroon contains all of these permissions, it is considered valid.
+    // If the list of permissions given is empty, then the macaroon is
+    // considered valid only based on issuance authority and caveat validity.
+    // An empty list of permissions is therefore equivalent to saying "skip
+    // checking permissions" (unless check_default_perms_from_full_method is
+    // specified).
     repeated MacaroonPermission permissions = 2;
+
+    // The RPC method to check the macaroon against. This is only used if there
+    // are custom `uri:<rpcpackage>.<ServiceName>/<MethodName>` permissions in
+    // the permission list above. To check a macaroon against the list of
+    // permissions of a certain RPC method, query the `ListPermissions` RPC
+    // first, extract the permissions for the method, and then pass them in the
+    // `permissions` field above.
     string fullMethod = 3;
+
+    // If this field is set to true, then the permissions list above MUST be
+    // empty. The default permissions for the provided fullMethod will be used
+    // to check the macaroon. This is equivalent to looking up the permissions
+    // for a method in the `ListPermissions` RPC and then calling this RPC with
+    // the permission list returned from that call. Without this flag, the list
+    // of permissions must be non-empty for the check to actually perform a
+    // permission check.
+    bool check_default_perms_from_full_method = 4;
 }
 
 message CheckMacPermResponse {
@@ -4716,6 +5230,22 @@ message RPCMiddlewareRequest {
     intercept message.
     */
     uint64 msg_id = 7;
+
+    /*
+    The metadata pairs that were sent along with the original gRPC request via
+    the golang context.Context using explicit [gRPC
+    metadata](https://grpc.io/docs/guides/metadata/). Context values are not
+    propagated via gRPC and so we send any pairs along explicitly here so that
+    the interceptor can access them.
+    */
+    map<string, MetadataValues> metadata_pairs = 9;
+}
+
+message MetadataValues {
+    /*
+    The set of metadata values that correspond to the metadata key.
+    */
+    repeated string values = 1;
 }
 
 message StreamAuth {

--- a/proto/router.proto
+++ b/proto/router.proto
@@ -1,22 +1,43 @@
 syntax = "proto3";
 
-import "lightning.proto";
-
 package routerrpc;
 
+import "lightning.proto";
+
 option go_package = "github.com/lightningnetwork/lnd/lnrpc/routerrpc";
+
+/*
+ * Comments in this file will be directly parsed into the API
+ * Documentation as descriptions of the associated method, message, or field.
+ * These descriptions should go right above the definition of the object, and
+ * can be in either block or // comment format.
+ *
+ * An RPC method can be matched to an lncli command by placing a line in the
+ * beginning of the description in exactly the following format:
+ * lncli: `methodname`
+ *
+ * Failure to specify the exact name of the command will cause documentation
+ * generation to fail.
+ *
+ * More information on how exactly the gRPC documentation is generated from
+ * this proto file can be found here:
+ * https://github.com/lightninglabs/lightning-api
+ */
 
 // Router is a service that offers advanced interaction with the router
 // subsystem of the daemon.
 service Router {
-    /*
+    /* lncli: `sendpayment`
     SendPaymentV2 attempts to route a payment described by the passed
     PaymentRequest to the final destination. The call returns a stream of
-    payment updates.
+    payment updates. When using this RPC, make sure to set a fee limit, as the
+    default routing fee limit is 0 sats. Without a non-zero fee limit only
+    routes without fees will be attempted which often fails with
+    FAILURE_REASON_NO_ROUTE.
     */
     rpc SendPaymentV2 (SendPaymentRequest) returns (stream lnrpc.Payment);
 
-    /*
+    /* lncli: `trackpayment`
     TrackPaymentV2 returns an update stream for the payment identified by the
     payment hash.
     */
@@ -32,24 +53,13 @@ service Router {
     */
     rpc TrackPayments (TrackPaymentsRequest) returns (stream lnrpc.Payment);
 
-    /*
+    /* lncli: `estimateroutefee`
     EstimateRouteFee allows callers to obtain a lower bound w.r.t how much it
     may cost to send an HTLC to the target end destination.
     */
     rpc EstimateRouteFee (RouteFeeRequest) returns (RouteFeeResponse);
 
-    /*
-    Deprecated, use SendToRouteV2. SendToRoute attempts to make a payment via
-    the specified route. This method differs from SendPayment in that it
-    allows users to specify a full route manually. This can be used for
-    things like rebalancing, and atomic swaps. It differs from the newer
-    SendToRouteV2 in that it doesn't return the full HTLC information.
-    */
-    rpc SendToRoute (SendToRouteRequest) returns (SendToRouteResponse) {
-        option deprecated = true;
-    }
-
-    /*
+    /* lncli: `sendtoroute`
     SendToRouteV2 attempts to make a payment via the specified route. This
     method differs from SendPayment in that it allows users to specify a full
     route manually. This can be used for things like rebalancing, and atomic
@@ -57,21 +67,21 @@ service Router {
     */
     rpc SendToRouteV2 (SendToRouteRequest) returns (lnrpc.HTLCAttempt);
 
-    /*
+    /* lncli: `resetmc`
     ResetMissionControl clears all mission control state and starts with a clean
     slate.
     */
     rpc ResetMissionControl (ResetMissionControlRequest)
         returns (ResetMissionControlResponse);
 
-    /*
+    /* lncli: `querymc`
     QueryMissionControl exposes the internal mission control state to callers.
     It is a development feature.
     */
     rpc QueryMissionControl (QueryMissionControlRequest)
         returns (QueryMissionControlResponse);
 
-    /*
+    /* lncli: `importmc`
     XImportMissionControl is an experimental API that imports the state provided
     to the internal mission control's state, using all results which are more
     recent than our existing values. These values will only be imported
@@ -80,20 +90,20 @@ service Router {
     rpc XImportMissionControl (XImportMissionControlRequest)
         returns (XImportMissionControlResponse);
 
-    /*
+    /* lncli: `getmccfg`
     GetMissionControlConfig returns mission control's current config.
     */
     rpc GetMissionControlConfig (GetMissionControlConfigRequest)
         returns (GetMissionControlConfigResponse);
 
-    /*
+    /* lncli: `setmccfg`
     SetMissionControlConfig will set mission control's config, if the config
     provided is valid.
     */
     rpc SetMissionControlConfig (SetMissionControlConfigRequest)
         returns (SetMissionControlConfigResponse);
 
-    /*
+    /* lncli: `queryprob`
     Deprecated. QueryProbability returns the current success probability
     estimate for a given node pair and amount. The call returns a zero success
     probability if no channel is available or if the amount violates min/max
@@ -102,10 +112,14 @@ service Router {
     rpc QueryProbability (QueryProbabilityRequest)
         returns (QueryProbabilityResponse);
 
-    /*
+    /* lncli: `buildroute`
     BuildRoute builds a fully specified route based on a list of hop public
     keys. It retrieves the relevant channel policies from the graph in order to
     calculate the correct fees and time locks.
+    Note that LND will use its default final_cltv_delta if no value is supplied.
+    Make sure to add the correct final_cltv_delta depending on the invoice
+    restriction. Moreover the caller has to make sure to provide the
+    payment_addr if the route is paying an invoice which signaled it.
     */
     rpc BuildRoute (BuildRouteRequest) returns (BuildRouteResponse);
 
@@ -115,23 +129,6 @@ service Router {
     */
     rpc SubscribeHtlcEvents (SubscribeHtlcEventsRequest)
         returns (stream HtlcEvent);
-
-    /*
-    Deprecated, use SendPaymentV2. SendPayment attempts to route a payment
-    described by the passed PaymentRequest to the final destination. The call
-    returns a stream of payment status updates.
-    */
-    rpc SendPayment (SendPaymentRequest) returns (stream PaymentStatus) {
-        option deprecated = true;
-    }
-
-    /*
-    Deprecated, use TrackPaymentV2. TrackPayment returns an update stream for
-    the payment identified by the payment hash.
-    */
-    rpc TrackPayment (TrackPaymentRequest) returns (stream PaymentStatus) {
-        option deprecated = true;
-    }
 
     /**
     HtlcInterceptor dispatches a bi-directional streaming RPC in which
@@ -143,7 +140,7 @@ service Router {
     rpc HtlcInterceptor (stream ForwardHtlcInterceptResponse)
         returns (stream ForwardHtlcInterceptRequest);
 
-    /*
+    /* lncli: `updatechanstatus`
     UpdateChanStatus attempts to manually set the state of a channel
     (enabled, disabled, or auto). A manual "disable" request will cause the
     channel to stay disabled until a subsequent manual request of either
@@ -151,6 +148,44 @@ service Router {
     */
     rpc UpdateChanStatus (UpdateChanStatusRequest)
         returns (UpdateChanStatusResponse);
+
+    /*
+    XAddLocalChanAliases is an experimental API that creates a set of new
+    channel SCID alias mappings. The final total set of aliases in the manager
+    after the add operation is returned. This is only a locally stored alias,
+    and will not be communicated to the channel peer via any message. Therefore,
+    routing over such an alias will only work if the peer also calls this same
+    RPC on their end. If an alias already exists, an error is returned
+    */
+    rpc XAddLocalChanAliases (AddAliasesRequest) returns (AddAliasesResponse);
+
+    /*
+    XDeleteLocalChanAliases is an experimental API that deletes a set of alias
+    mappings. The final total set of aliases in the manager after the delete
+    operation is returned. The deletion will not be communicated to the channel
+    peer via any message.
+    */
+    rpc XDeleteLocalChanAliases (DeleteAliasesRequest)
+        returns (DeleteAliasesResponse);
+
+    /*
+    XFindBaseLocalChanAlias is an experimental API that looks up the base scid
+    for a local chan alias that was registered during the current runtime.
+    */
+    rpc XFindBaseLocalChanAlias (FindBaseAliasRequest)
+        returns (FindBaseAliasResponse);
+
+    /* lncli: `deletefwdhistory`
+    DeleteForwardingHistory allows the caller to delete forwarding history
+    events with a timestamp at or before a specified time. This is useful
+    for implementing data retention policies for privacy purposes. The call
+    deletes events in batches and returns statistics including the total number
+    of events deleted and the aggregate fees earned from those events. The
+    deletion is performed in a transaction-safe manner with configurable batch
+    sizes to avoid holding large database locks.
+    */
+    rpc DeleteForwardingHistory (DeleteForwardingHistoryRequest)
+        returns (DeleteForwardingHistoryResponse);
 }
 
 message SendPaymentRequest {
@@ -164,13 +199,6 @@ message SendPaymentRequest {
     */
     int64 amt = 2;
 
-    /*
-    Number of millisatoshis to send.
-
-    The fields amt and amt_msat are mutually exclusive.
-    */
-    int64 amt_msat = 12;
-
     // The hash to use within the payment's HTLC
     bytes payment_hash = 3;
 
@@ -179,9 +207,6 @@ message SendPaymentRequest {
     timelock for the final hop.
     */
     int32 final_cltv_delta = 4;
-
-    // An optional payment addr to be included within the last hop of the route.
-    bytes payment_addr = 20;
 
     /*
     A bare-bones invoice for a payment within the Lightning Network.  With the
@@ -193,10 +218,11 @@ message SendPaymentRequest {
     string payment_request = 5;
 
     /*
-    An upper limit on the amount of time we should spend when attempting to
-    fulfill the payment. This is expressed in seconds. If we cannot make a
-    successful payment within this time frame, an error will be returned.
-    This field must be non-zero.
+    An optional limit, expressed in seconds, on the time to wait before
+    attempting the first HTLC. Once HTLCs are in flight, the payment will
+    not be aborted until the HTLCs are either settled or failed. If the field
+    is not set or is explicitly set to zero, the default value of 60 seconds
+    will be applied.
     */
     int32 timeout_seconds = 6;
 
@@ -210,38 +236,11 @@ message SendPaymentRequest {
     */
     int64 fee_limit_sat = 7;
 
-    /*
-    The maximum number of millisatoshis that will be paid as a fee of the
-    payment. If this field is left to the default value of 0, only zero-fee
-    routes will be considered. This usually means single hop routes connecting
-    directly to the destination. To send the payment without a fee limit, use
-    max int here.
-
-    The fields fee_limit_sat and fee_limit_msat are mutually exclusive.
-    */
-    int64 fee_limit_msat = 13;
+    reserved 8;
 
     /*
-    Deprecated, use outgoing_chan_ids. The channel id of the channel that must
-    be taken to the first hop. If zero, any channel may be used (unless
-    outgoing_chan_ids are set).
-    */
-    uint64 outgoing_chan_id = 8 [jstype = JS_STRING, deprecated = true];
-
-    /*
-    The channel ids of the channels are allowed for the first hop. If empty,
-    any channel may be used.
-    */
-    repeated uint64 outgoing_chan_ids = 19;
-
-    /*
-    The pubkey of the last hop of the route. If empty, any hop may be used.
-    */
-    bytes last_hop_pubkey = 14;
-
-    /*
-    An optional maximum total time lock for the route. This should not exceed
-    lnd's `--max-cltv-expiry` setting. If zero, then the value of
+    An optional maximum total time lock for the route. This should not
+    exceed lnd's `--max-cltv-expiry` setting. If zero, then the value of
     `--max-cltv-expiry` is enforced.
     */
     int32 cltv_limit = 9;
@@ -259,6 +258,29 @@ message SendPaymentRequest {
     must be encoded as base64.
     */
     map<uint64, bytes> dest_custom_records = 11;
+
+    /*
+    Number of millisatoshis to send.
+
+    The fields amt and amt_msat are mutually exclusive.
+    */
+    int64 amt_msat = 12;
+
+    /*
+    The maximum number of millisatoshis that will be paid as a fee of the
+    payment. If this field is left to the default value of 0, only zero-fee
+    routes will be considered. This usually means single hop routes connecting
+    directly to the destination. To send the payment without a fee limit, use
+    max int here.
+
+    The fields fee_limit_sat and fee_limit_msat are mutually exclusive.
+    */
+    int64 fee_limit_msat = 13;
+
+    /*
+    The pubkey of the last hop of the route. If empty, any hop may be used.
+    */
+    bytes last_hop_pubkey = 14;
 
     // If set, circular payments to self are permitted.
     bool allow_self_payment = 15;
@@ -285,6 +307,18 @@ message SendPaymentRequest {
     bool no_inflight_updates = 18;
 
     /*
+    The channel ids of the channels are allowed for the first hop. If empty,
+    any channel may be used.
+    */
+    repeated uint64 outgoing_chan_ids = 19;
+
+    /*
+    An optional payment addr to be included within the last hop of the route.
+    This is also called payment secret in specifications (e.g. BOLT 11).
+    */
+    bytes payment_addr = 20;
+
+    /*
     The largest payment split that should be attempted when making a payment if
     splitting is necessary. Setting this value will effectively cause lnd to
     split more aggressively, vs only when it thinks it needs to. Note that this
@@ -302,6 +336,24 @@ message SendPaymentRequest {
     only, to 1 to optimize for reliability only or a value inbetween for a mix.
     */
     double time_pref = 23;
+
+    /*
+    If set, the payment loop can be interrupted by manually canceling the
+    payment context, even before the payment timeout is reached. Note that the
+    payment may still succeed after cancellation, as in-flight attempts can
+    still settle afterwards. Canceling will only prevent further attempts from
+    being sent.
+    */
+    bool cancelable = 24;
+
+    /*
+    An optional field that can be used to pass an arbitrary set of TLV records
+    to the first hop peer of this payment. This can be used to pass application
+    specific data during the payment attempt. Record types are required to be in
+    the custom range >= 65536. When using REST, the values must be encoded as
+    base64.
+    */
+    map<uint64, bytes> first_hop_custom_records = 25;
 }
 
 message TrackPaymentRequest {
@@ -325,14 +377,39 @@ message TrackPaymentsRequest {
 
 message RouteFeeRequest {
     /*
-    The destination once wishes to obtain a routing fee quote to.
+    The destination one wishes to obtain a routing fee quote to. If set, this
+    parameter requires the amt_sat parameter also to be set. This parameter
+    combination triggers a graph based routing fee estimation as opposed to a
+    payment probe based estimate in case a payment request is provided. The
+    graph based estimation is an algorithm that is executed on the in memory
+    graph. Hence its runtime is significantly shorter than a payment probe
+    estimation that sends out actual payments to the network.
     */
     bytes dest = 1;
 
     /*
-    The amount one wishes to send to the target destination.
+    The amount one wishes to send to the target destination. It is only to be
+    used in combination with the dest parameter.
     */
     int64 amt_sat = 2;
+
+    /*
+    A payment request of the target node that the route fee request is intended
+    for. Its parameters are input to probe payments that estimate routing fees.
+    The timeout parameter can be specified to set a maximum time on the probing
+    attempt. Cannot be used in combination with dest and amt_sat.
+    */
+    string payment_request = 3;
+
+    /*
+    A user preference of how long a probe payment should maximally be allowed to
+    take, denoted in seconds. The probing payment loop is aborted if this
+    timeout is reached. Note that the probing process itself can take longer
+    than the timeout if the HTLC becomes delayed or stuck. Canceling the context
+    of this call will not cancel the payment loop, the duration is only
+    controlled by the timeout parameter.
+    */
+    uint32 timeout = 4;
 }
 
 message RouteFeeResponse {
@@ -348,6 +425,12 @@ message RouteFeeResponse {
     value.
     */
     int64 time_lock_delay = 2;
+
+    /*
+    An indication whether a probing payment succeeded or whether and why it
+    failed. FAILURE_REASON_NONE indicates success.
+    */
+    lnrpc.PaymentFailureReason failure_reason = 5;
 }
 
 message SendToRouteRequest {
@@ -364,14 +447,15 @@ message SendToRouteRequest {
     routes, incorrect payment details, or insufficient funds.
     */
     bool skip_temp_err = 3;
-}
 
-message SendToRouteResponse {
-    // The preimage obtained by making the payment.
-    bytes preimage = 1;
-
-    // The failure message in case the payment failed.
-    lnrpc.Failure failure = 2;
+    /*
+    An optional field that can be used to pass an arbitrary set of TLV records
+    to the first hop peer of this payment. This can be used to pass application
+    specific data during the payment attempt. Record types are required to be in
+    the custom range >= 65536. When using REST, the values must be encoded as
+    base64.
+    */
+    map<uint64, bytes> first_hop_custom_records = 4;
 }
 
 message ResetMissionControlRequest {
@@ -634,8 +718,20 @@ message BuildRouteRequest {
     */
     repeated bytes hop_pubkeys = 4;
 
-    // An optional payment addr to be included within the last hop of the route.
+    /*
+    An optional payment addr to be included within the last hop of the route.
+    This is also called payment secret in specifications (e.g. BOLT 11).
+    */
     bytes payment_addr = 5;
+
+    /*
+    An optional field that can be used to pass an arbitrary set of TLV records
+    to the first hop peer of this payment. This can be used to pass application
+    specific data during the payment attempt. Record types are required to be in
+    the custom range >= 65536. When using REST, the values must be encoded as
+    base64.
+    */
+    map<uint64, bytes> first_hop_custom_records = 6;
 }
 
 message BuildRouteResponse {
@@ -786,62 +882,11 @@ enum FailureDetail {
     INVALID_KEYSEND = 20;
     MPP_IN_PROGRESS = 21;
     CIRCULAR_ROUTE = 22;
-}
-
-enum PaymentState {
-    /*
-    Payment is still in flight.
-    */
-    IN_FLIGHT = 0;
-
-    /*
-    Payment completed successfully.
-    */
-    SUCCEEDED = 1;
-
-    /*
-    There are more routes to try, but the payment timeout was exceeded.
-    */
-    FAILED_TIMEOUT = 2;
-
-    /*
-    All possible routes were tried and failed permanently. Or were no
-    routes to the destination at all.
-    */
-    FAILED_NO_ROUTE = 3;
-
-    /*
-    A non-recoverable error has occurred.
-    */
-    FAILED_ERROR = 4;
-
-    /*
-    Payment details incorrect (unknown hash, invalid amt or
-    invalid final cltv delta)
-    */
-    FAILED_INCORRECT_PAYMENT_DETAILS = 5;
-
-    /*
-    Insufficient local balance.
-    */
-    FAILED_INSUFFICIENT_BALANCE = 6;
-}
-
-message PaymentStatus {
-    // Current state the payment is in.
-    PaymentState state = 1;
-
-    /*
-    The pre-image of the payment when state is SUCCEEDED.
-    */
-    bytes preimage = 2;
-
-    reserved 3;
-
-    /*
-    The HTLCs made in attempt to settle the payment [EXPERIMENTAL].
-    */
-    repeated lnrpc.HTLCAttempt htlcs = 4;
+    INVOICE_ALREADY_SETTLED = 23;
+    HTLC_INVOICE_TYPE_MISMATCH = 24;
+    AMP_ERROR = 25;
+    AMP_RECONSTRUCTION = 26;
+    EXTERNAL_VALIDATION_FAILED = 27;
 }
 
 message CircuitKey {
@@ -856,6 +901,10 @@ message ForwardHtlcInterceptRequest {
     /*
     The key of this forwarded htlc. It defines the incoming channel id and
     the index in this channel.
+
+    Interceptor clients should handle requests for the same circuit key
+    idempotently. Requests may be replayed after reconnect, and an htlc that was
+    previously offered off-chain may be offered again after it moves on-chain.
     */
     CircuitKey incoming_circuit_key = 1;
 
@@ -890,16 +939,30 @@ message ForwardHtlcInterceptRequest {
     bytes onion_blob = 9;
 
     // The block height at which this htlc will be auto-failed to prevent the
-    // channel from force-closing.
+    // channel from force-closing. For on-chain htlcs, this field is the
+    // settlement deadline instead and no automatic fail-back is attempted.
     int32 auto_fail_height = 10;
+
+    // The custom records of the peer's incoming p2p wire message.
+    map<uint64, bytes> in_wire_custom_records = 11;
 }
 
 /**
 ForwardHtlcInterceptResponse enables the caller to resolve a previously hold
 forward. The caller can choose either to:
 - `Resume`: Execute the default behavior (usually forward).
+- `ResumeModified`: Execute the default behavior (usually forward) with HTLC
+                    field modifications.
 - `Reject`: Fail the htlc backwards.
 - `Settle`: Settle this htlc with a given preimage.
+
+Once the incoming channel has force-closed and the HTLC is being resolved
+on-chain (see auto_fail_height), only `Settle` has any effect. The HTLC can no
+longer be resumed or failed back off-chain, so `Resume`, `ResumeModified`, and
+`Fail` return a stream-terminating error. The HTLC stays held until it is
+settled with a preimage, the on-chain resolver completes, or it expires
+on-chain. Clients should reconnect to receive any held HTLCs that remain
+unresolved.
 */
 message ForwardHtlcInterceptResponse {
     /**
@@ -928,12 +991,40 @@ message ForwardHtlcInterceptResponse {
     // For backwards-compatibility reasons, TEMPORARY_CHANNEL_FAILURE is the
     // default value for this field.
     lnrpc.Failure.FailureCode failure_code = 5;
+
+    // The amount that was set on the p2p wire message of the incoming HTLC.
+    // This field is ignored if the action is not RESUME_MODIFIED or the amount
+    // is zero.
+    uint64 in_amount_msat = 6;
+
+    // The amount to set on the p2p wire message of the resumed HTLC. This field
+    // is ignored if the action is not RESUME_MODIFIED or the amount is zero.
+    uint64 out_amount_msat = 7;
+
+    // Any custom records that should be set on the p2p wire message message of
+    // the resumed HTLC. This field is ignored if the action is not
+    // RESUME_MODIFIED.
+    //
+    // This map will merge with the existing set of custom records (if any),
+    // replacing any conflicting types. Note that there currently is no support
+    // for deleting existing custom records (they can only be replaced).
+    map<uint64, bytes> out_wire_custom_records = 8;
 }
 
 enum ResolveHoldForwardAction {
+    // SETTLE is an action that is used to settle an HTLC instead of forwarding
+    // it.
     SETTLE = 0;
+
+    // FAIL is an action that is used to fail an HTLC backwards.
     FAIL = 1;
+
+    // RESUME is an action that is used to resume a forward HTLC.
     RESUME = 2;
+
+    // RESUME_MODIFIED is an action that is used to resume a hold forward HTLC
+    // with modifications specified during interception.
+    RESUME_MODIFIED = 3;
 }
 
 message UpdateChanStatusRequest {
@@ -949,4 +1040,62 @@ enum ChanStatusAction {
 }
 
 message UpdateChanStatusResponse {
+}
+
+message AddAliasesRequest {
+    repeated lnrpc.AliasMap alias_maps = 1;
+}
+
+message AddAliasesResponse {
+    repeated lnrpc.AliasMap alias_maps = 1;
+}
+
+message DeleteAliasesRequest {
+    repeated lnrpc.AliasMap alias_maps = 1;
+}
+
+message DeleteAliasesResponse {
+    repeated lnrpc.AliasMap alias_maps = 1;
+}
+
+message FindBaseAliasRequest {
+    // The alias we want to look up the base scid for.
+    uint64 alias = 1;
+}
+
+message FindBaseAliasResponse {
+    // The base scid that resulted from the base scid look up.
+    uint64 base = 1;
+}
+
+message DeleteForwardingHistoryRequest {
+    // Specify the cutoff time for deletion using one of the following options.
+    // Events with a timestamp at or before the cutoff are deleted.
+    oneof time_spec {
+        // Absolute Unix timestamp (seconds). Events at or before this time
+        // are deleted.
+        uint64 delete_before_time = 1;
+
+        // Relative duration string indicating how far back to delete, e.g.
+        // "-30d" deletes events at or before 30 days ago.
+        // Standard Go: "-24h", "-1.5h"
+        // Custom units: "-1d", "-1w", "-1M", "-1y"
+        // Supported: ns, us/µs, ms, s, m, h, d (days), w (weeks),
+        // M (months=30.44d), y (years=365.25d).
+        // Use negative values to specify time in the past.
+        string delete_before_duration = 2;
+    }
+}
+
+message DeleteForwardingHistoryResponse {
+    // Number of forwarding events deleted.
+    uint64 events_deleted = 1;
+
+    // Total fees earned from deleted events (in millisatoshis).
+    // This is the sum of (amt_in - amt_out) for all deleted events, which
+    // can be used for accounting purposes.
+    int64 total_fee_msat = 2;
+
+    // Status message.
+    string status = 3;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,9 +27,8 @@ use grpc::{
         Invoice, ListChannelsRequest, ListChannelsResponse, ListInvoiceRequest,
         ListInvoiceResponse, ListPaymentsRequest, ListPaymentsResponse, NewAddressRequest,
         NewAddressResponse, PayReq, PayReqString, Payment, PendingChannelsRequest,
-        PendingChannelsResponse, SendCoinsRequest, SendCoinsResponse, SendRequest, SendResponse,
-        TransactionDetails, WalletBalanceRequest, WalletBalanceResponse,
-        lightning_client::LightningClient,
+        PendingChannelsResponse, SendCoinsRequest, SendCoinsResponse, TransactionDetails,
+        WalletBalanceRequest, WalletBalanceResponse, lightning_client::LightningClient,
     },
     routerrpc::{SendPaymentRequest, TrackPaymentRequest, router_client::RouterClient},
 };
@@ -317,20 +316,6 @@ impl Lnd {
             .map(Response::into_inner)
     }
 
-    pub async fn send_payment_sync(
-        &self,
-        send_request: SendRequest,
-    ) -> Result<SendResponse, Status> {
-        let span = span!(self.tracer => "lnrpc". "Lightning" / "SendPaymentSync");
-
-        self.lightning
-            .clone()
-            .send_payment_sync(send_request)
-            .with_context(opentelemetry::Context::current_with_span(span))
-            .await
-            .map(Response::into_inner)
-    }
-
     pub async fn wallet_balance(&self) -> Result<WalletBalanceResponse, Status> {
         let span = span!(self.tracer => "lnrpc". "Lightning" / "WalletBalance");
 
@@ -400,7 +385,9 @@ impl Lnd {
 
         self.lightning
             .clone()
-            .pending_channels(PendingChannelsRequest {})
+            .pending_channels(PendingChannelsRequest {
+                include_raw_tx: false,
+            })
             .with_context(opentelemetry::Context::current_with_span(span))
             .await
             .map(Response::into_inner)


### PR DESCRIPTION
## What

All four protos re-vendored from the `v0.21.1-beta` tag: `lightning.proto`, `router.proto`, `invoices.proto`, `chainkit.proto`. Imports are unchanged (`lightning.proto` only), so nothing new had to be vendored. README badge moved `v0.13.1-beta` → `v0.21.1-beta`.

## RPC drift

Removed, all seven of them the payment RPCs dropped in v0.21.0:

| Proto | Removed |
|---|---|
| `lightning.proto` | `SendPayment`, `SendPaymentSync`, `SendToRoute`, `SendToRouteSync` |
| `router.proto` | `SendPayment`, `SendToRoute`, `TrackPayment` (the deprecated v1 forms) |

Added: `DeleteCanceledInvoice`, `GetDebugInfo`, `SendOnionMessage`, `SubscribeOnionMessages`, `DeleteForwardingHistory`, `XAddLocalChanAliases`, `XDeleteLocalChanAliases`, `XFindBaseLocalChanAlias`, `HtlcModifier`, `GetBlockHeader`.

## What broke here

Three things, all fallout from the removals:

1. **`SendRequest` / `SendResponse` gone** — dropped from the `lnrpc` import list.
2. **`send_payment_sync` deleted** — it wrapped `Lightning/SendPaymentSync`. Nothing calls it. `send_payment` and `track_payment` are unaffected: they already target `SendPaymentV2`/`TrackPaymentV2` (`lib.rs:503,517`).
3. **`PendingChannelsRequest` gained `include_raw_tx`** — set to `false`, which is the behaviour the server got before the field existed.

## Verification

`cargo build --all-targets` and `cargo fmt --check` both pass — that build is exactly what `checks.yml` runs.